### PR TITLE
feat: 카카오 로그인 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "recoil": "^0.7.7",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^0.8.0"
+    "vaul": "^0.8.0",
+    "vite-plugin-mkcert": "1.17.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.6",

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,8 @@
+const KAKAO_AUTH_URL = 'https://kauth.kakao.com';
+
+const CLIENT_ID = import.meta.env.VITE_REST_KEY;
+const REDIRECT_URI = import.meta.env.VITE_REDIRECT_URI;
+
+export const AUTH_URL = `${KAKAO_AUTH_URL}/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+//TODO) reissue 관련 작성

--- a/src/components/common/atom/TabItem.tsx
+++ b/src/components/common/atom/TabItem.tsx
@@ -1,13 +1,13 @@
 import SvgIcon from '@components/common/atom/SvgIcon';
 import Typography from '@components/common/atom/Typography';
-import { ActivitiesTypes } from '@constants/activities';
+import { TabItemTypes } from '@constants/activities';
 import { IconKeyType } from '@constants/icons';
 import { useFlow } from '@hooks/useStackFlow';
 
 interface TabItemProps {
-  icon: ActivitiesTypes;
+  icon: TabItemTypes;
   name: string;
-  pathname: ActivitiesTypes;
+  pathname: TabItemTypes;
   isDone: boolean;
 }
 
@@ -21,7 +21,7 @@ export default function TabItem({
   const handleClick = () => replace(icon, {});
 
   const getIcon = () => {
-    const iconMap: Record<ActivitiesTypes, string> = {
+    const iconMap: Record<TabItemTypes, string> = {
       Home: isDone && pathname === 'Home' ? 'HomeFill' : 'Home',
       Peer: isDone && pathname === 'Peer' ? 'PeopleFill' : 'People',
       Project: isDone && pathname === 'Project' ? 'ProjectFill' : 'Project',

--- a/src/components/common/molecule/BottomNavigation.tsx
+++ b/src/components/common/molecule/BottomNavigation.tsx
@@ -1,5 +1,5 @@
 import TabItem from '@components/common/atom/TabItem';
-import { ActivitiesTypes } from '@constants/activities';
+import { TabItemTypes } from '@constants/activities';
 import { useActivity } from '@stackflow/react';
 
 export default function BottomNavigation() {
@@ -17,9 +17,9 @@ export default function BottomNavigation() {
       {activities.map(({ icon, name }) => (
         <TabItem
           key={icon}
-          icon={icon as ActivitiesTypes}
+          icon={icon as TabItemTypes}
           name={name}
-          pathname={activity.name as ActivitiesTypes}
+          pathname={activity.name as TabItemTypes}
           isDone={
             activity.transitionState === 'enter-done' ||
             activity.transitionState === 'enter-active'

--- a/src/components/common/molecule/Modal.tsx
+++ b/src/components/common/molecule/Modal.tsx
@@ -4,13 +4,13 @@ import {
   ModalProps as ModalPropsWithNextui,
   Modal as ModalWithNextui,
 } from '@nextui-org/react';
-import { modalState } from '@store/modal';
-import { useRecoilState } from 'recoil';
-import Typography from '../atom/Typography';
 
-interface ModalProps extends ModalPropsWithNextui {
+import Typography from '../atom/Typography';
+import useModal from '@hooks/useModal';
+
+interface ModalProps extends Omit<ModalPropsWithNextui, 'children'> {
   modalHeader: string;
-  modalBody: string;
+  modalBody: string | JSX.Element;
   footer: React.ReactNode;
 }
 
@@ -20,25 +20,25 @@ export default function Modal({
   footer,
   ...props
 }: ModalProps) {
-  /** Open Modal 버튼 삭제 & 해당 함수는 props로 사용할 예정 */
-  const [modal, setModal] = useRecoilState(modalState);
+  const { isOpen, openModal, closeModal } = useModal();
+  const modalType: 'default' | 'login' | 'error' = 'default';
 
-  const handleSetIsOpen = (isOpen: boolean) => {
-    setModal({
-      ...modal,
-      isOpen: !isOpen,
-      modalType: 'default',
-    });
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      openModal(modalType);
+    } else {
+      closeModal();
+    }
   };
 
   return (
     <>
-      {modal.isOpen && (
+      {isOpen && (
         <ModalWithNextui
           {...props}
           backdrop="opaque"
-          isOpen={modal.isOpen}
-          onOpenChange={handleSetIsOpen}
+          isOpen={isOpen}
+          onOpenChange={handleOpenChange}
           hideCloseButton={true}
           classNames={{
             backdrop:
@@ -47,7 +47,7 @@ export default function Modal({
         >
           <ModalContent className="w-[310px] m-auto">
             <div className="pt-10 pb-4">
-              <Typography className="text-center mb-2" variant={'header03'}>
+              <Typography className="text-center mb-5" variant={'header03'}>
                 {modalHeader}
               </Typography>
               <Typography className="text-center" variant={'body04'}>

--- a/src/components/login/organism/LoginModal.tsx
+++ b/src/components/login/organism/LoginModal.tsx
@@ -1,0 +1,44 @@
+import Modal from '@components/common/molecule/Modal';
+import ButtonContainer from '@components/common/molecule/ButtonContainer';
+import Button from '@components/common/atom/Button';
+import { AUTH_URL } from '@apis/auth';
+import useModal from '@hooks/useModal';
+
+export default function LoginModal() {
+  const { isOpen, modalType } = useModal();
+  const modalBody = (
+    <>
+      회원가입 후 단계 별 결과 분석을 통해
+      <br />
+      구성한 피어 카드를 확인하세요
+    </>
+  );
+
+  const kakaoLogin = () => {
+    window.location.href = AUTH_URL;
+  };
+
+  const modalFooter = (
+    <ButtonContainer direction={'col'}>
+      <Button
+        className="flex-1 box-border bg-secondary-yellow"
+        onClick={kakaoLogin}
+      >
+        카카오 회원가입
+      </Button>
+      <Button className="flex-1 box-border bg-gray07">Apple 회원가입</Button>
+    </ButtonContainer>
+  );
+
+  return (
+    <>
+      {isOpen && modalType === 'login' && (
+        <Modal
+          modalHeader="회원가입"
+          modalBody={modalBody}
+          footer={modalFooter}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/login/template/Redirect.tsx
+++ b/src/components/login/template/Redirect.tsx
@@ -1,0 +1,38 @@
+import { ActivityComponentType } from '@stackflow/react';
+import { useFlow } from '@hooks/useStackFlow';
+import Spinner from '@components/common/atom/Spinner';
+import useToken from '@hooks/useToken';
+import { LocalStorage } from '@constants/localStorage';
+import { useEffect } from 'react';
+
+interface AuthData {
+  memberId: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+const Redirect: ActivityComponentType = () => {
+  const { replace } = useFlow();
+  const { updateToken } = useToken();
+
+  const url = window.location.search;
+  const params: URLSearchParams = new URLSearchParams(url);
+
+  const { memberId, accessToken, refreshToken }: AuthData = {
+    memberId: params.get('memberId') || '',
+    accessToken: params.get('accessToken') || '',
+    refreshToken: params.get('refreshToken') || '',
+  };
+
+  useEffect(() => {
+    if (memberId && accessToken && refreshToken) {
+      localStorage.setItem(LocalStorage.MemberId, memberId);
+      updateToken(accessToken, refreshToken);
+      replace('Home', {});
+    }
+  }, [memberId, accessToken, refreshToken]);
+
+  return <Spinner />;
+};
+
+export default Redirect;

--- a/src/components/login/template/Redirect.tsx
+++ b/src/components/login/template/Redirect.tsx
@@ -2,7 +2,7 @@ import { ActivityComponentType } from '@stackflow/react';
 import { useFlow } from '@hooks/useStackFlow';
 import Spinner from '@components/common/atom/Spinner';
 import useToken from '@hooks/useToken';
-import { LocalStorage } from '@constants/localStorage';
+import { Member_Id } from '@constants/localStorage';
 import { useEffect } from 'react';
 
 interface AuthData {
@@ -26,7 +26,7 @@ const Redirect: ActivityComponentType = () => {
 
   useEffect(() => {
     if (memberId && accessToken && refreshToken) {
-      localStorage.setItem(LocalStorage.MemberId, memberId);
+      localStorage.setItem(Member_Id, memberId);
       updateToken(accessToken, refreshToken);
       replace('Home', {});
     }

--- a/src/components/peer/template/Peer.tsx
+++ b/src/components/peer/template/Peer.tsx
@@ -1,10 +1,24 @@
 import BottomNavigation from '@components/common/molecule/BottomNavigation';
 import { ActivityComponentType } from '@stackflow/react';
+import Button from '@components/common/atom/Button';
+import useModal from '@hooks/useModal';
+import useToken from '@hooks/useToken';
+import LoginModal from '@components/login/organism/LoginModal';
 
 const Peer: ActivityComponentType = () => {
+  const { openModal } = useModal();
+  const { accessToken } = useToken();
+
+  const handleCheckPeerType = () => {
+    if (!accessToken) {
+      openModal('login');
+    }
+  };
+
   return (
     <div>
-      <div>Peer</div>
+      <Button onClick={handleCheckPeerType}>내 피어 유형 확인하기</Button>
+      <LoginModal />
       <BottomNavigation />
     </div>
   );

--- a/src/constants/activities.ts
+++ b/src/constants/activities.ts
@@ -1,4 +1,5 @@
 import Home from '@components/home/template/Home';
+import Redirect from '@components/login/template/Redirect';
 import Mypage from '@components/mypage/template/Mypage';
 import Notification from '@components/notification/template/Notification';
 import Peer from '@components/peer/template/Peer';
@@ -6,6 +7,7 @@ import Project from '@components/project/template/Project';
 
 export const Activities = {
   Home,
+  Redirect,
   Peer,
   Project,
   Notification,

--- a/src/constants/activities.ts
+++ b/src/constants/activities.ts
@@ -14,4 +14,13 @@ export const Activities = {
   Mypage,
 };
 
+export const TabItem = {
+  Home,
+  Peer,
+  Project,
+  Notification,
+  Mypage,
+};
+
 export type ActivitiesTypes = keyof typeof Activities;
+export type TabItemTypes = keyof typeof TabItem;

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,0 +1,7 @@
+export const LocalStorage = {
+  MemberId: 'memberId',
+  AccessToken: 'accessToken',
+  RefreshToken: 'refreshToken',
+};
+
+export type LocalStorageKeyType = keyof typeof LocalStorage;

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,7 +1,3 @@
-export const LocalStorage = {
-  MemberId: 'memberId',
-  AccessToken: 'accessToken',
-  RefreshToken: 'refreshToken',
-};
-
-export type LocalStorageKeyType = keyof typeof LocalStorage;
+export const Member_Id = 'memberId';
+export const Access_Token = 'accessToken';
+export const Refresh_Token = 'refreshToken';

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,28 @@
+import { useRecoilState } from 'recoil';
+import { modalState, ModalStateType } from '@store/modal';
+
+export default function useModal() {
+  const [modal, setModal] = useRecoilState<ModalStateType>(modalState);
+
+  const openModal = (modalType: 'default' | 'error' | 'login') => {
+    setModal(prevModal => ({
+      ...prevModal,
+      isOpen: true,
+      modalType,
+    }));
+  };
+
+  const closeModal = () => {
+    setModal(prevModal => ({
+      ...prevModal,
+      isOpen: false,
+    }));
+  };
+
+  return {
+    isOpen: modal.isOpen,
+    modalType: modal.modalType,
+    openModal,
+    closeModal,
+  };
+}

--- a/src/hooks/useStackFlow.tsx
+++ b/src/hooks/useStackFlow.tsx
@@ -10,6 +10,7 @@ export const { Stack, useFlow, useStepFlow } = stackflow({
     historySyncPlugin({
       routes: {
         Home: '/',
+        Redirect: '/login/kakao',
         Peer: '/peer',
         Project: '/project',
         Notification: '/notification',

--- a/src/hooks/useToken.tsx
+++ b/src/hooks/useToken.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { LocalStorage } from '@constants/localStorage';
+
+export default function useToken() {
+  const [accessToken, setAccessToken] = useState(
+    () => localStorage.getItem(LocalStorage.AccessToken) || '',
+  );
+  const [refreshToken, setRefreshToken] = useState(
+    () => localStorage.getItem(LocalStorage.RefreshToken) || '',
+  );
+
+  const updateToken = (newAccessToken: string, newRefreshToken: string) => {
+    setAccessToken(newAccessToken);
+    setRefreshToken(newRefreshToken);
+    localStorage.setItem(LocalStorage.AccessToken, newAccessToken);
+    localStorage.setItem(LocalStorage.RefreshToken, newRefreshToken);
+  };
+
+  const resetToken = () => {
+    setAccessToken('');
+    setRefreshToken('');
+    localStorage.removeItem(LocalStorage.AccessToken);
+    localStorage.removeItem(LocalStorage.RefreshToken);
+  };
+
+  return { accessToken, refreshToken, updateToken, resetToken };
+}

--- a/src/hooks/useToken.tsx
+++ b/src/hooks/useToken.tsx
@@ -1,26 +1,26 @@
 import { useState } from 'react';
-import { LocalStorage } from '@constants/localStorage';
+import { Access_Token, Refresh_Token } from '@constants/localStorage';
 
 export default function useToken() {
   const [accessToken, setAccessToken] = useState(
-    () => localStorage.getItem(LocalStorage.AccessToken) || '',
+    () => localStorage.getItem(Access_Token) || '',
   );
   const [refreshToken, setRefreshToken] = useState(
-    () => localStorage.getItem(LocalStorage.RefreshToken) || '',
+    () => localStorage.getItem(Refresh_Token) || '',
   );
 
   const updateToken = (newAccessToken: string, newRefreshToken: string) => {
     setAccessToken(newAccessToken);
     setRefreshToken(newRefreshToken);
-    localStorage.setItem(LocalStorage.AccessToken, newAccessToken);
-    localStorage.setItem(LocalStorage.RefreshToken, newRefreshToken);
+    localStorage.setItem(Access_Token, newAccessToken);
+    localStorage.setItem(Refresh_Token, newRefreshToken);
   };
 
   const resetToken = () => {
     setAccessToken('');
     setRefreshToken('');
-    localStorage.removeItem(LocalStorage.AccessToken);
-    localStorage.removeItem(LocalStorage.RefreshToken);
+    localStorage.removeItem(Access_Token);
+    localStorage.removeItem(Refresh_Token);
   };
 
   return { accessToken, refreshToken, updateToken, resetToken };

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -1,14 +1,14 @@
 import { atom } from 'recoil';
 
-interface ModalState {
+export interface ModalStateType {
   isOpen: boolean;
-  modalType: 'default' | 'error';
+  modalType: 'default' | 'error' | 'login';
 }
 
-export const modalState = atom<ModalState>({
+export const modalState = atom<ModalStateType>({
   key: 'modalState',
   default: {
-    isOpen: true,
+    isOpen: false,
     modalType: 'default',
   },
 });


### PR DESCRIPTION
## 체크리스트
- [x] PR 제목의 형식 e.g. `feat: PR 등록`
- [x] Issue 
- [x] Label 
- [x] Assignees & Reviewers 

<br>

## PR 한 줄 요약
- 카카오 로그인을 구현하였습니다.

<br><br>

## 상세 작업 내용
- useModal 으로 modalType에 따라 OpenModal이 실행되도록 구현하였습니다.
- useToken 훅을 만들어 token값을 업데이트하거나 reset 하도록 구현하였습니다. 
- Modal 컴포넌트에서 children props가 필요한데 이는 ReactNode로 ModalContent를 의미하는데 footer의 요소만 modal마다 다르기 때문에 footer props를 사용하고 NextUI의 props의 children 사용은 제외하였습니다.
[nextui modal](https://nextui.org/docs/components/modal)
<br><br>

## 참고 사항
- 배포하면서 로그인 과정 중 redirect 페이지 이동이 필요해 route에 추가하면서 Activity 상수와 (전체 페이지 라우팅 상수) bottomNavigation 상수 (Home, Peer, Project, MyPage)와 구분하기 위해 TabItem 상수를 추가했습니다 한번 확인부탁드립니다
- api의 auth에 KAKAO_AUTH_URL나 CLIENT_ID 같은 경우 상수이기 때문에 constants에 두어야할지 고민을 했는데 결국 로그인 할 경우에만 사용되기 때문에 `api/auth.ts`에 두었는데 의견 부탁드립니다

<br><br>

## 관련 이슈
- Close #24 

<br><br>
