### PR TITLE
feat: accessToken 웹 앱 통신을 통한 자동 로그인 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-error-boundary": "^4.0.12",
     "react-hot-toast": "^2.4.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.8.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
 import BottomSheet from '@components/common/organism/BottomSheet';
+import LoginModal from '@components/pages/login/organism/LoginModal';
 import { Stack } from '@hooks/useStackFlow';
+import { WebviewBridge } from '@utils/webview';
+import { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 
 function App() {
+  useEffect(() => {
+    WebviewBridge.registerMessageListener();
+  }, []);
   return (
     <div className="w-screen min-h-screen flex justify-center">
       {/* Notice)Stack은 StackFlow의 진입점입니다. */}
@@ -16,6 +22,7 @@ function App() {
           },
         }}
       />
+      <LoginModal />
     </div>
   );
 }

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,4 @@
+import { getAccessToken } from '@utils/token';
 import axios, { AxiosResponse } from 'axios';
 
 export const http = axios.create({
@@ -12,6 +13,10 @@ export const http = axios.create({
 
 http.interceptors.request.use(async config => {
   // TODO: authorization logic
+  const accessToken = getAccessToken();
+  if (accessToken) {
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+  }
   return config;
 });
 

--- a/src/components/common/molecule/BottomNavigation.tsx
+++ b/src/components/common/molecule/BottomNavigation.tsx
@@ -13,7 +13,7 @@ export default function BottomNavigation() {
   ];
 
   return (
-    <div className="fixed left-2/4 translate-x-[-50%] bottom-0 flex flex-row items-center max-w-[600px] w-full h-[64px] border-t-1 border-x-1 rounded-t-xl">
+    <div className="fixed left-2/4 translate-x-[-50%] bottom-0 flex flex-row items-center max-w-screen-md w-full h-[64px] border-t-1 border-x-1 rounded-t-xl">
       {activities.map(({ icon, name }) => (
         <TabItem
           key={icon}

--- a/src/components/common/organism/Header.tsx
+++ b/src/components/common/organism/Header.tsx
@@ -25,7 +25,7 @@ export default function Header({
   };
 
   return (
-    <header className="max-w-[600px] px-5 mx-auto">
+    <header className="max-w-screen-md px-5 mx-auto">
       {showBackButton && (
         <section className="py-[22px] w-full flex items-center">
           <IconButton

--- a/src/components/pages/login/template/RedirectPage.tsx
+++ b/src/components/pages/login/template/RedirectPage.tsx
@@ -1,5 +1,6 @@
 import Spinner from '@components/common/atom/Spinner';
 import { Member_Id } from '@constants/localStorage';
+import useHistory from '@hooks/useHistory';
 import { useFlow } from '@hooks/useStackFlow';
 import useToken from '@hooks/useToken';
 import { ActivityComponentType } from '@stackflow/react';
@@ -13,6 +14,7 @@ interface AuthData {
 
 const RedirectPage: ActivityComponentType = () => {
   const { push } = useFlow();
+  const { history } = useHistory();
   const { updateToken } = useToken();
 
   const url = window.location.search;
@@ -28,7 +30,7 @@ const RedirectPage: ActivityComponentType = () => {
     if (memberId && accessToken && refreshToken) {
       localStorage.setItem(Member_Id, memberId);
       updateToken(accessToken, refreshToken);
-      push('HomePage', {});
+      push(history.activity, history.params);
     }
   }, [memberId, accessToken, refreshToken]);
 

--- a/src/components/pages/mypage/template/MyPage.tsx
+++ b/src/components/pages/mypage/template/MyPage.tsx
@@ -1,6 +1,5 @@
 import Button from '@components/common/atom/Button';
 import BottomNavigation from '@components/common/molecule/BottomNavigation';
-import LoginModal from '@components/pages/login/organism/LoginModal';
 import useModal from '@hooks/useModal';
 import useToken from '@hooks/useToken';
 import { ActivityComponentType } from '@stackflow/react';
@@ -18,7 +17,6 @@ const MyPage: ActivityComponentType = () => {
   return (
     <div>
       <Button onClick={handleCheckPeerType}>내 피어 유형 확인하기</Button>
-      <LoginModal />
       <BottomNavigation />
     </div>
   );

--- a/src/components/pages/review/template/ReviewPage.tsx
+++ b/src/components/pages/review/template/ReviewPage.tsx
@@ -97,7 +97,7 @@ const ReviewPage: ActivityComponentType<ReviewPageParams> = ({ params }) => {
   return (
     <AppScreenContainer>
       <div className="w-screen min-h-screen flex justify-center">
-        <div className="w-full max-w-[690px] flex flex-col px-5">
+        <div className="w-full max-w-screen-md` flex flex-col px-5">
           <div className="box-border w-full h-[68px] px-2 py-ㅁ[18px] flex items-center justify-between bg-transparent">
             <IconButton
               iconProps={{

--- a/src/components/pages/review/template/ReviewPage.tsx
+++ b/src/components/pages/review/template/ReviewPage.tsx
@@ -1,5 +1,5 @@
-import IconButton from '@components/common/atom/IconButton';
 import Typography from '@components/common/atom/Typography';
+import NavigationHeader from '@components/common/molecule/NavigationHeader';
 import TestImage from '@components/pages/review/molecule/ReviewCenterImage';
 import TestHeader from '@components/pages/review/molecule/ReviewHeader';
 import OneLineReview from '@components/pages/review/organism/OneLineReview';
@@ -96,52 +96,45 @@ const ReviewPage: ActivityComponentType<ReviewPageParams> = ({ params }) => {
 
   return (
     <AppScreenContainer>
-      <div className="w-screen min-h-screen flex justify-center">
-        <div className="w-full max-w-screen-md` flex flex-col px-5">
-          <div className="box-border w-full h-[68px] px-2 py-ㅁ[18px] flex items-center justify-between bg-transparent">
-            <IconButton
-              iconProps={{
-                id: 'ArrowLeft',
-                color: 'black',
-              }}
-              onClick={handleClickBackButton}
-            />
-          </div>
-          <div className="flex flex-col items-center mt-6 gap-4">
-            <TestHeader type={type} curStep={curStep} trackStep={trackStep} />
-            {(curStep !== 4 || trackStep !== 7) && (
-              <TestImage
-                curStep={curStep}
-                trackStep={trackStep}
-                answerStep={answerStep}
-              />
-            )}
-            {!(curStep === 4 && (trackStep === 6 || trackStep === 7)) && (
-              <TwoWayPicker
-                curStep={curStep}
-                answerStep={answerStep}
-                handleClickNextStep={handleClickNextStep}
-              />
-            )}
-            {curStep === 4 && trackStep === 6 && (
-              <PeerType
-                answerStep={answerStep}
-                handleClick={handleClickPeerTypeButton}
-              />
-            )}
-            {curStep === 4 && trackStep === 7 && (
-              <OneLineReview answerStep={answerStep} />
-            )}
-          </div>
-        </div>
+      <NavigationHeader
+        backIconProps={{
+          isShow: true,
+          handleClick: handleClickBackButton,
+        }}
+      />
+      <div className="flex flex-col items-center mt-6 gap-4">
+        <TestHeader type={type} curStep={curStep} trackStep={trackStep} />
+        {(curStep !== 4 || trackStep !== 7) && (
+          <TestImage
+            curStep={curStep}
+            trackStep={trackStep}
+            answerStep={answerStep}
+          />
+        )}
+        {!(curStep === 4 && (trackStep === 6 || trackStep === 7)) && (
+          <TwoWayPicker
+            curStep={curStep}
+            answerStep={answerStep}
+            handleClickNextStep={handleClickNextStep}
+          />
+        )}
+        {curStep === 4 && trackStep === 6 && (
+          <PeerType
+            answerStep={answerStep}
+            handleClick={handleClickPeerTypeButton}
+          />
+        )}
         {curStep === 4 && trackStep === 7 && (
-          <FixedBottomButton handleClick={handleClickLastButton}>
-            <Typography variant="body02" fontColor="white">
-              시작하기
-            </Typography>
-          </FixedBottomButton>
+          <OneLineReview answerStep={answerStep} />
         )}
       </div>
+      {curStep === 4 && trackStep === 7 && (
+        <FixedBottomButton handleClick={handleClickLastButton}>
+          <Typography variant="body02" fontColor="white">
+            시작하기
+          </Typography>
+        </FixedBottomButton>
+      )}
     </AppScreenContainer>
   );
 };

--- a/src/components/pages/reviewResult/molecule/ShareDrawer.tsx
+++ b/src/components/pages/reviewResult/molecule/ShareDrawer.tsx
@@ -30,7 +30,7 @@ export default function ShareDrawer({
       open={openBottomSheet}
       onOpenChange={open => setOpenBottomSheet(open)}
     >
-      <DrawerContent className="mx-auto max-w-[600px]">
+      <DrawerContent className="mx-auto max-w-screen-md">
         <div className="p-4 flex justify-center gap-4">
           <div className="flex flex-col gap-2 items-center">
             <IconButton

--- a/src/components/pages/reviewResult/organism/LoadingResult.tsx
+++ b/src/components/pages/reviewResult/organism/LoadingResult.tsx
@@ -1,22 +1,18 @@
 import Spinner from '@components/common/atom/Spinner';
 import Typography from '@components/common/atom/Typography';
 import { useFlow } from '@hooks/useStackFlow';
+import { getAccessToken } from '@utils/token';
 import { Fragment, useEffect } from 'react';
 
-interface LoadingResultProps {
-  curStep: number;
-}
-
-export default function LoadingResult({ curStep }: LoadingResultProps) {
+export default function LoadingResult() {
   const { push } = useFlow();
-  const nextStep = String(curStep + 1);
 
   useEffect(() => {
-    if (curStep === 1) {
-      setTimeout(() => {
-        push('ReviewResultPage', { type: 'self', step: nextStep });
-      }, 1500);
-    }
+    setTimeout(() => {
+      if (getAccessToken())
+        push('ReviewResultPage', { type: 'self', step: '2' });
+      else push('ReviewResultPage', { type: 'self', step: '3' });
+    }, 1500);
   }, []);
 
   return (

--- a/src/components/pages/reviewResult/organism/ResultLoginRequired.tsx
+++ b/src/components/pages/reviewResult/organism/ResultLoginRequired.tsx
@@ -1,0 +1,104 @@
+import Typography from '@components/common/atom/Typography';
+import Card from '@components/pages/reviewResult/molecule/Card';
+
+import FixedBottomButton from '@components/wrapper/FixedBottomButton';
+import { CardType, Description, Keyword, Value } from '@constants/image';
+import useHistory from '@hooks/useHistory';
+import useModal from '@hooks/useModal';
+import useToken from '@hooks/useToken';
+import { motion } from 'framer-motion';
+import { Fragment, useEffect } from 'react';
+
+interface ResultLoginRequiredProps {
+  handleClick: () => void;
+}
+
+// TODO 데이터 서버에서 받아와야 함.
+// TODO Card image 변경 및 서버에서 데이터 받아와야 함.
+export default function ResultLoginRequired({
+  handleClick,
+}: ResultLoginRequiredProps) {
+  const { openModal } = useModal();
+  const { accessToken } = useToken();
+  const { history, handleChangeHistory } = useHistory();
+
+  useEffect(() => {
+    if (history.activity !== 'ReviewResultPage') {
+      handleChangeHistory('ReviewResultPage', { type: 'self', step: '2' });
+    }
+    if (!accessToken) {
+      openModal('login');
+    }
+  }, [history]);
+
+  const cardTypes = [
+    {
+      type: 'CardPurple',
+      value: Value.CardPurple,
+      keyword: Keyword.CardPurple,
+      description: Description.CardPurple,
+    },
+    {
+      type: 'CardOrange',
+      value: Value.CardOrange,
+      keyword: Keyword.CardOrange,
+      description: Description.CardOrange,
+    },
+    {
+      type: 'CardPink',
+      value: Value.CardPink,
+      keyword: Keyword.CardPink,
+      description: Description.CardPink,
+    },
+    {
+      type: 'CardYellow',
+      value: Value.CardYellow,
+      keyword: Keyword.CardYellow,
+      description: Description.CardYellow,
+    },
+  ];
+
+  const cardVariants = {
+    hidden: { opacity: 0, y: 20 },
+    visible: (index: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        delay: index * 0.2, // 각 카드의 등장 시간 간격
+      },
+    }),
+  };
+
+  return (
+    <Fragment>
+      <div className="box-content w-full h-[68px] py-[18px] mt-6 flex items-center justify-between bg-transparent px-5">
+        <Typography variant="header01" fontColor="gray07">
+          {'username님의 셀프 테스트 결과를 \n 분석한 피어 카드에요'}
+        </Typography>
+      </div>
+      <div className="py-6 flex flex-col gap-3">
+        {cardTypes.map((card, index) => (
+          <motion.div
+            key={card.type}
+            custom={index}
+            initial="hidden"
+            animate="visible"
+            variants={cardVariants}
+          >
+            <Card
+              type={card.type as CardType}
+              value={card.value}
+              keyword={card.keyword}
+              description={card.description}
+            />
+          </motion.div>
+        ))}
+      </div>
+      <FixedBottomButton handleClick={handleClick}>
+        <Typography variant="body02" fontColor="white">
+          내 피어 유형 확인하기
+        </Typography>
+      </FixedBottomButton>
+    </Fragment>
+  );
+}

--- a/src/components/pages/reviewResult/template/ReviewResultPage.tsx
+++ b/src/components/pages/reviewResult/template/ReviewResultPage.tsx
@@ -1,5 +1,6 @@
 import AnalyzePeerCard from '@components/pages/reviewResult/organism/AnalyzePeerCard';
 import LoadingResult from '@components/pages/reviewResult/organism/LoadingResult';
+import ResultLoginRequired from '@components/pages/reviewResult/organism/ResultLoginRequired';
 import ResultShare from '@components/pages/reviewResult/organism/ResultShare';
 import AppScreenContainer from '@components/wrapper/AppScreenContainter';
 import { useFlow } from '@hooks/useStackFlow';
@@ -22,15 +23,16 @@ const ReviewResultPage: ActivityComponentType<ReviewResultPageParams> = ({
   };
 
   const bgColor =
-    curStep > 2
+    curStep > 1
       ? `bg-gradient-to-r from-indigo-300 via-purple-300 to-pink-300`
       : 'bg-transparent';
 
   return (
     <AppScreenContainer className={bgColor}>
-      {curStep === 1 && <LoadingResult curStep={curStep} />}
+      {curStep === 1 && <LoadingResult />}
       {curStep === 2 && <AnalyzePeerCard handleClick={handleClick} />}
-      {curStep === 3 && <ResultShare type={params.type} curStep={curStep} />}
+      {curStep === 3 && <ResultLoginRequired handleClick={handleClick} />}
+      {curStep === 4 && <ResultShare type={params.type} curStep={curStep} />}
     </AppScreenContainer>
   );
 };

--- a/src/components/wrapper/AppScreenContainter.tsx
+++ b/src/components/wrapper/AppScreenContainter.tsx
@@ -14,7 +14,7 @@ export default function AppScreenContainer({
       <div
         className={`${props.className} w-screen min-h-screen flex justify-center px-5`}
       >
-        <div className="w-full max-w-[600px] flex flex-col items-center mb-20">
+        <div className="w-full max-w-screen-md flex flex-col items-center mb-20">
           {children}
         </div>
       </div>

--- a/src/components/wrapper/FixedBottomButton.tsx
+++ b/src/components/wrapper/FixedBottomButton.tsx
@@ -14,7 +14,7 @@ export default function FixedBottomButton({
 }: FixedBottomButton) {
   return ReactDOM.createPortal(
     <div className="fixed z-30 left-2/4 translate-x-[-50%] bottom-5 w-full flex justify-center">
-      <div className="w-full max-w-[600px] px-5 sm:px-0">
+      <div className="w-full max-w-screen-md px-5 sm:px-0">
         <Button onClick={handleClick} {...props}>
           {children}
         </Button>

--- a/src/components/wrapper/FixedButtonContainer.tsx
+++ b/src/components/wrapper/FixedButtonContainer.tsx
@@ -14,7 +14,9 @@ export default function FixedButtonContainer({
 
   return ReactDOM.createPortal(
     <div className="fixed z-30 left-2/4 translate-x-[-50%] bottom-5 w-full flex justify-center">
-      <div className={` w-full max-w-[600px] px-5 flex ${flexDirection} gap-2`}>
+      <div
+        className={` w-full max-w-screen-md px-5 flex ${flexDirection} gap-2`}
+      >
         {children}
       </div>
     </div>,

--- a/src/components/wrapper/PageContainer.tsx
+++ b/src/components/wrapper/PageContainer.tsx
@@ -12,7 +12,7 @@ export default function PageContainer({
     <div
       className={`${props.className} w-screen min-h-screen flex justify-center`}
     >
-      <div className="w-full max-w-[690px] flex flex-col items-center px-5 mb-20">
+      <div className="w-full max-w-screen-md flex flex-col items-center px-5 mb-20">
         {children}
       </div>
     </div>

--- a/src/hooks/useHistory.tsx
+++ b/src/hooks/useHistory.tsx
@@ -1,0 +1,20 @@
+import { PageTypes } from '@constants/activities';
+import { historyState } from '@store/history';
+import { useRecoilState } from 'recoil';
+
+export default function useHistory() {
+  const [history, setHistory] = useRecoilState(historyState);
+
+  const handleChangeHistory = (
+    activity: PageTypes,
+    parmas: Record<string, string>,
+  ) => {
+    setHistory(prev => ({
+      ...prev,
+      activity,
+      parmas,
+    }));
+  };
+
+  return { history, handleChangeHistory };
+}

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,5 +1,5 @@
-import { useRecoilState } from 'recoil';
 import { modalState, ModalStateType } from '@store/modal';
+import { useRecoilState } from 'recoil';
 
 export default function useModal() {
   const [modal, setModal] = useRecoilState<ModalStateType>(modalState);

--- a/src/hooks/useToken.tsx
+++ b/src/hooks/useToken.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
 import { Access_Token, Refresh_Token } from '@constants/localStorage';
+import { WebviewBridge } from '@utils/webview';
+import { useState } from 'react';
 
 export default function useToken() {
   const [accessToken, setAccessToken] = useState(
@@ -14,6 +15,13 @@ export default function useToken() {
     setRefreshToken(newRefreshToken);
     localStorage.setItem(Access_Token, newAccessToken);
     localStorage.setItem(Refresh_Token, newRefreshToken);
+    WebviewBridge.postMessage({
+      type: 'login',
+      data: {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+      },
+    });
   };
 
   const resetToken = () => {

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -1,0 +1,17 @@
+import { PageTypes } from '@constants/activities';
+import { persistAtom } from '@store/recoilPersist';
+import { atom } from 'recoil';
+
+type HistoryStateType = {
+  activity: PageTypes;
+  params: Record<string, string>;
+};
+
+export const historyState = atom<HistoryStateType>({
+  key: 'historyState',
+  default: {
+    activity: 'HomePage',
+    params: {},
+  },
+  effects_UNSTABLE: [persistAtom],
+});

--- a/src/store/recoilPersist.ts
+++ b/src/store/recoilPersist.ts
@@ -1,0 +1,6 @@
+import { recoilPersist } from 'recoil-persist';
+
+export const { persistAtom } = recoilPersist({
+  key: 'history-persist',
+  storage: localStorage,
+});

--- a/src/type/global.d.ts
+++ b/src/type/global.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  ReactNativeWebView: {
+    postMessage: (message: string) => void;
+  };
+}

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,0 +1,13 @@
+export const getRgbaColorWithOpacity = (color: string, opacity: number) => {
+  // color를 rgba 형태로 변환
+  const rgbColor = [
+    parseInt(color.slice(1, 3), 16),
+    parseInt(color.slice(3, 5), 16),
+    parseInt(color.slice(5, 7), 16),
+  ];
+
+  // 최종 스타일 객체 반환, tailwindcss에서는 rgba 사용 불가
+  return {
+    backgroundColor: `rgba(${rgbColor.join(', ')}, ${opacity})`,
+  };
+};

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,0 +1,8 @@
+import { Access_Token, Refresh_Token } from '@constants/localStorage';
+
+export const getAccessToken = () => localStorage.getItem(Access_Token);
+export const getRefreshToken = () => localStorage.getItem(Refresh_Token);
+export const setAccessToken = (accessToken: string) =>
+  localStorage.setItem(Access_Token, JSON.stringify(accessToken));
+export const setRefreshToken = (refreshToken: string) =>
+  localStorage.setItem(Refresh_Token, JSON.stringify({ refreshToken }));

--- a/src/utils/webview.ts
+++ b/src/utils/webview.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { setAccessToken, setRefreshToken } from '@utils/token';
+
+export class WebviewBridge {
+  static postMessage({ type, data }: WebviewPostMessageRequestType) {
+    if (
+      navigator.userAgent.includes('iPhone') ||
+      navigator.userAgent.includes('Android')
+    ) {
+      const webview = window.ReactNativeWebView;
+      if (webview) {
+        const message = JSON.stringify({ type, data });
+        console.log(message);
+        webview.postMessage(message);
+      }
+    } else {
+      return;
+    }
+  }
+
+  static registerMessageListener() {
+    const global = navigator.userAgent.includes('iPhone') ? window : document;
+    global.addEventListener('message', event => {
+      const messageEvent = event as MessageEvent;
+      try {
+        const message: WebviewMessageEventResponseType = JSON.parse(
+          messageEvent.data,
+        );
+        switch (message.type) {
+          case 'init':
+            // eslint-disable-next-line no-case-declarations
+            const { accessToken, refreshToken } = message.data;
+            setAccessToken(accessToken);
+            setRefreshToken(refreshToken);
+            break;
+          default:
+            break;
+        }
+      } catch (error) {
+        console.error('Error parsing message:', error);
+      }
+    });
+  }
+}
+
+type WebviewPostMessageRequestType = {
+  type: string;
+  data: any;
+};
+
+type WebviewMessageEventResponseType = {
+  type: string;
+  data: any;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12552,6 +12552,7 @@ __metadata:
     react-error-boundary: "npm:^4.0.12"
     react-hot-toast: "npm:^2.4.1"
     recoil: "npm:^0.7.7"
+    recoil-persist: "npm:^5.1.0"
     storybook: "npm:^7.6.6"
     tailwind-merge: "npm:^2.2.0"
     tailwindcss: "npm:^3.4.0"
@@ -13294,6 +13295,15 @@ __metadata:
     source-map: "npm:~0.6.1"
     tslib: "npm:^2.0.1"
   checksum: d719633be8029e28f23b8191d4a525c5dbdac721792ab3cb5e9dfcf1694fb93f3c147b186916195a9c7fa0711f1e4990ba457cdcee02faed3899d4a80da1bd1f
+  languageName: node
+  linkType: hard
+
+"recoil-persist@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "recoil-persist@npm:5.1.0"
+  peerDependencies:
+    recoil: ^0.7.2
+  checksum: 76cf9c0a41511d50d5f7b5b8feaf5d1df275617aa9c4980a8517a1f364a83df63ac159d002e1da8d5dba402b138cb38cc196c44b010ebf3f5b4943945d008687
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 체크리스트
- [x] PR 제목의 형식 e.g. `feat: PR 등록`
- [x] Issue 
- [x] Label 
- [x] Assignees & Reviewers 

<br>

## PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
webview 통신을 하여 자동로그인을 구현하였습니다. 
<br><br>

## 상세 작업 내용
<!-- 작업한 상세 내용을 작성해 주세요.-->
- webview 브릿지 클래스를 만들었습니다. 
앞으로 webview 통신 관련해서는 해당 클래스에서 처리하도록 하겠습니다!
객체 및 메서드로 만들지 않은 이유는 앞으로 코드가 더 많아질텐데 객체로 관리하기에는 변수 공유하기도 어려울 것 같아서 class로 작성했습니다.

- useHistory 훅을 만들었습니다.
앞으로 login modal을 띄울 일이 있으면 미리 useHistory에 저장해두고 Redirect에서 자동으로 변환되게 해주면 됩니다.
추가로, recoil-persist를 추가하였으니, kakao login 때문에 redirect시 상태가 날아가기 때문에 모든 상태를 recoil-persist로 감싸야할 것 같아요.

<br><br>

## 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
recoil-persist는 따로 큰 설정해주지 않아도 되니까 간단하게 코드 살펴보시기만 해도 파악되실거에요.

<br><br>

## 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 닫힙니다. -->
<!-- ex) Close #14 -->

- Close #44 
- Close #45 
<br><br>
