### PR TITLE
fix: 홈 페이지 및 동료페이지 쿼리 타입 수정

### DIFF
--- a/src/components/common/molecule/ProfileListItem.tsx
+++ b/src/components/common/molecule/ProfileListItem.tsx
@@ -2,16 +2,15 @@ import Typography from '@components/common/atom/Typography';
 import { cardItem, CardType } from '@constants/card';
 import { JOB_LIST, PART_LIST } from '@constants/member';
 import { getPartJobTitle } from '@utils/getTitleValue';
-import { JobType, PartType } from '@constants/member';
 import SvgIcon from '../atom/SvgIcon';
 
 interface ProfileListItemProps {
   isMyProfile: boolean;
   testType: CardType;
   username: string;
-  part: PartType;
+  part: string;
   score: number;
-  job: JobType;
+  job: string;
   introduce: string;
   children?: React.ReactNode;
 }

--- a/src/components/pages/home/molecule/UserProfileList.tsx
+++ b/src/components/pages/home/molecule/UserProfileList.tsx
@@ -1,45 +1,48 @@
 import Button from '@components/common/atom/Button';
 import ProfileListItem from '@components/common/molecule/ProfileListItem';
 import { useFlow } from '@hooks/useStackFlow';
-import { MemberSimpleProfileDTO } from '@hooks/api/useGetSearchPeerType';
+import { MemberSimpleDTOPage } from '@hooks/api/useGetSearchPeerPart';
 
 export default function UserProfileList({
   data,
 }: {
-  data: MemberSimpleProfileDTO[];
+  data: MemberSimpleDTOPage[];
 }) {
   const { push } = useFlow();
+
   const handlePeerDetail = (memberId: string) => {
     push('PeerDetailPage', { memberId });
   };
 
-  if (data?.length === 0) {
+  if (!data[0]) {
     return <h1>데이터가 없습니다</h1>;
   }
 
   return (
     <ul className="w-full flex flex-col">
-      {data?.map((user, index: number) => (
-        <li key={index}>
-          <ProfileListItem
-            isMyProfile={false}
-            testType={user.peerTestType}
-            username={user.name}
-            part={user.part}
-            score={user.totalScore}
-            job={user.job}
-            introduce={user.oneLiner}
-          >
-            <Button
-              buttonSize="md"
-              buttonVariant="tertiary"
-              onClick={() => handlePeerDetail(user?.memberId.toString())}
+      {data?.map(item =>
+        item?.memberSimpleProfileDtoList?.map(user => (
+          <li key={user.memberId}>
+            <ProfileListItem
+              isMyProfile={false}
+              testType={user.peerTestType}
+              username={user.name}
+              part={user.part}
+              score={user.totalScore}
+              job={user.job}
+              introduce={user.oneLiner}
             >
-              자세히
-            </Button>
-          </ProfileListItem>
-        </li>
-      ))}
+              <Button
+                buttonSize="md"
+                buttonVariant="tertiary"
+                onClick={() => handlePeerDetail(user.memberId.toString())}
+              >
+                자세히
+              </Button>
+            </ProfileListItem>
+          </li>
+        )),
+      )}
     </ul>
   );
 }

--- a/src/components/pages/home/template/HomePage.tsx
+++ b/src/components/pages/home/template/HomePage.tsx
@@ -51,7 +51,9 @@ const HomePage: ActivityComponentType = () => {
             <Tab key="FRONT_END" title="FE 개발자" />,
             <Tab key="BACK_END" title="BE 개발자" />,
           </UnderlineTabs>
-          <UserProfileList data={data} />
+          {data && (
+            <UserProfileList data={data.pages.flatMap(page => page.result)} />
+          )}
           <IntersectionBox ref={intersectionRef} />
 
           {isFetchingNextPage && <Spinner />}

--- a/src/components/pages/moreFeedback/template/MoreFeedbackPage.tsx
+++ b/src/components/pages/moreFeedback/template/MoreFeedbackPage.tsx
@@ -11,8 +11,6 @@ import IntersectionBox from '@components/common/atom/IntersectionBox';
 const MoreFeedbackPage: ActivityComponentType = () => {
   const { data, fetchNextPage, isFetchingNextPage } = useGetMoreFeedback();
 
-  console.log(data);
-
   const { pop } = useFlow();
   const handleClick = () => pop();
 
@@ -23,11 +21,13 @@ const MoreFeedbackPage: ActivityComponentType = () => {
       <TopHeader title="동료들의 한 줄 피드백" onClick={handleClick} />
 
       <ul className="w-full flex flex-col gap-3 px-[24px] py-[20px]">
-        {data?.map(item => (
-          <li>
-            <Talk type="dimed">{item}</Talk>
-          </li>
-        ))}
+        {data?.pages.map(item =>
+          item.result.feedbackList.map(feedback => (
+            <li>
+              <Talk type="dimed">{feedback}</Talk>
+            </li>
+          )),
+        )}
       </ul>
 
       <IntersectionBox ref={intersectionRef} />

--- a/src/hooks/api/useGetMoreFeedback.tsx
+++ b/src/hooks/api/useGetMoreFeedback.tsx
@@ -11,21 +11,19 @@ interface AllFeedbackDTOPage {
 }
 
 const getMoreFeedback = async (
-  pageParam: number,
+  page: number,
 ): Promise<ApiResponse<AllFeedbackDTOPage>> => {
-  const response = await http.get(`/member/mypage/feedback?page=${pageParam}`);
-  return { ...response.data, pageParam };
+  const response = await http.get(`/member/mypage/feedback?page=${page}`);
+  return response.data;
 };
 
 export const useGetMoreFeedback = () =>
   useInfiniteQuery({
     queryKey: ['getMoreFeedback'],
     queryFn: ({ pageParam = 1 }) => getMoreFeedback(pageParam),
-    getNextPageParam: lastPage => {
-      const nextPage =
-        lastPage?.result?.isLast === false ? lastPage.pageParam + 1 : undefined;
-      return nextPage;
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const nextPage = allPages.length + 1;
+      return lastPage.result.isLast ? undefined : nextPage;
     },
-    select: data =>
-      data.pages?.flatMap(feedback => feedback?.result?.feedbackList),
   });

--- a/src/hooks/api/useGetSearchPeerPart.tsx
+++ b/src/hooks/api/useGetSearchPeerPart.tsx
@@ -1,18 +1,13 @@
 import { http, ApiResponse } from '@apis/index';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 
-interface MemberSimpleDTOPage {
+export interface MemberSimpleDTOPage {
   memberSimpleProfileDtoList: MemberSimpleProfileDTO[];
   totalElements: number;
   currentPageElements: number;
   totalPage: number;
   isFirst: boolean;
   isLast: boolean;
-}
-
-interface PageResponse<T> extends ApiResponse<T> {
-  currentPage: number;
 }
 
 export interface MemberSimpleProfileDTO {
@@ -27,25 +22,22 @@ export interface MemberSimpleProfileDTO {
 
 export const getSearchPeerPart = async (
   peerPart: string,
-  pageParam: number,
-): Promise<PageResponse<MemberSimpleDTOPage>> => {
+  page: number,
+): Promise<ApiResponse<MemberSimpleDTOPage>> => {
   const response = await http.get(
-    `/home/search/peer-part?part=${peerPart}&page=${pageParam}`,
+    `/home/search/peer-part?part=${peerPart}&page=${page}`,
   );
-  return { ...response.data, pageParam };
+  return response.data;
 };
 
 export const useGetSearchPeerPart = (peerPart: string) =>
-  useInfiniteQuery<PageResponse<MemberSimpleDTOPage>, AxiosError>({
+  useInfiniteQuery<ApiResponse<MemberSimpleDTOPage>>({
     queryKey: ['getSearchPeerPart', peerPart],
-    queryFn: ({ pageParam = 1 }) => getSearchPeerPart(peerPart, pageParam),
-    getNextPageParam: lastPage => {
-      const nextPage =
-        lastPage?.result?.isLast === false ? lastPage.pageParam + 1 : undefined;
-      return nextPage;
+    queryFn: ({ pageParam = 1 }) =>
+      getSearchPeerPart(peerPart, pageParam as number),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const nextPage = allPages.length + 1;
+      return lastPage?.result?.isLast ? undefined : nextPage;
     },
-    select: data =>
-      (data?.pages ?? []).flatMap(
-        part => part?.result?.memberSimpleProfileDtoList ?? [],
-      ),
   });

--- a/src/utils/getTitleValue.ts
+++ b/src/utils/getTitleValue.ts
@@ -1,7 +1,7 @@
 import { JobType, PartType } from '@constants/member';
 
 export const getPartJobTitle = (
-  key: JobType | PartType,
+  key: string,
   list: { title: string; job?: JobType; part?: PartType }[],
 ): string => {
   const partJob = list.find(item => item.job === key || item.part === key);


### PR DESCRIPTION
## 체크리스트
- [x] PR 제목의 형식 e.g. `feat: PR 등록`
- [x] Issue 
- [x] Label 
- [x] Assignees & Reviewers 

<br>

## PR 한 줄 요약
- 동료페이지와 홈페이지의 query 타입들을 수정하였습니다.

<br><br>

## 상세 작업 내용
- select 옵션을 사용하지않고 각 페이지에서 데이터를 mapping 하였습니다.

<br><br>

## 참고 사항
- 머지했을 때 다른 충돌사항이 있는지 확인부탁드립니다!

<br><br>

## 관련 이슈

- Close #74 

<br><br>
