### PR TITLE
feat: 프로젝트 참가 신청 수락/거부 기능 구현

### DIFF
--- a/src/components/common/molecule/RadioTabs.tsx
+++ b/src/components/common/molecule/RadioTabs.tsx
@@ -13,11 +13,11 @@ export default function RadioTabs({ children, ...props }: RadioTabsProps) {
       aria-label="Options"
       color="primary"
       variant="solid"
-      className="flex w-full justify-center"
+      className="flex w-full justify-center px-4"
       classNames={{
-        tabList: 'bg-gray01',
+        tabList: 'w-full bg-gray01',
         cursor: 'bg-white border-1',
-        tab: '!w-[524px] !h-[48px]',
+        tab: '!h-[48px]',
         tabContent: `${FontVariantsClassName.body03} text-gray04 group-data-[selected=true]:text-gray06`,
       }}
     >

--- a/src/components/wrapper/Header.tsx
+++ b/src/components/wrapper/Header.tsx
@@ -60,7 +60,7 @@ interface RightButtonProps {
 
 function RightButton({ text, handleClick }: RightButtonProps) {
   return (
-    <button onClick={handleClick} className="ml-auto">
+    <button onClick={handleClick} className="min-w-[24px] h-full">
       <Typography variant="body03" fontColor="gray07">
         {text}
       </Typography>

--- a/src/constants/activities.ts
+++ b/src/constants/activities.ts
@@ -16,6 +16,7 @@ import MyProjectListPage from '@pages/peer/project/template/MyProjectListPage';
 import PeerTypePage from '@pages/peer/type/template/PeerTypePage';
 import ProjectCreatePage from '@pages/project/create/template/ProjectCreatePage';
 import ProjectPage from '@pages/project/index/template/ProjectPage';
+import ProjectJoinPage from '@pages/project/join/template/ProjectJoinPage';
 import ProjectDetailPage from '@pages/project/projectId/template/ProjectDetailPage';
 import ProjectProposePage from '@pages/project/propose/template/ProjectProposePage';
 import ReviewPage from '@pages/review/index/template/ReviewPage';
@@ -47,6 +48,7 @@ export const Pages = {
   ProjectCreatePage,
   ProjectDetailPage,
   ProjectProposePage,
+  ProjectJoinPage,
   DeveloperPage: DeveloperPage,
 };
 
@@ -65,6 +67,7 @@ export const PageRoutes: Record<keyof typeof Pages, string> = {
   ProjectDetailPage: '/project/:id',
   ProjectCreatePage: '/project/create',
   ProjectProposePage: '/project/:id/propose',
+  ProjectJoinPage: 'project/:id/peer/:subTargetId',
   NotificationPage: '/notification',
   MyPage: '/mypage',
   SettingPage: '/mypage/setting',

--- a/src/hooks/api/project/projectId/requestJoin/usePostProjectRequestJoinAccept.tsx
+++ b/src/hooks/api/project/projectId/requestJoin/usePostProjectRequestJoinAccept.tsx
@@ -1,0 +1,41 @@
+import useErrorHandler from '@hooks/common/useErrorHandler';
+import { useMutation } from '@tanstack/react-query';
+import { ProjectInviteSuccessType } from '@type/index';
+import { ApiResponse, http } from '@utils/API';
+import { AxiosError } from 'axios';
+import toast from 'react-hot-toast';
+
+interface ProjectRequestJoinAcceptDTO {
+  projectId: number;
+  peerId: number;
+}
+
+interface ProjectRequestJoinDeclineDTO extends ProjectInviteSuccessType {}
+
+const postProjectRequestJoinAccept = async ({
+  projectId,
+  peerId,
+}: ProjectRequestJoinAcceptDTO): Promise<
+  ApiResponse<ProjectRequestJoinDeclineDTO>
+> => {
+  return await http.post(
+    `/project/${projectId}/request-join/${peerId}/accept`,
+    {
+      projectId,
+      peerId,
+    },
+  );
+};
+
+export default function usePostProjectRequestJoinAccept() {
+  const { handleError } = useErrorHandler();
+  return useMutation({
+    mutationFn: postProjectRequestJoinAccept,
+    onSuccess: () => {
+      toast.success('프로젝트 참여 신청이 허용되었습니다');
+    },
+    onError: (error: AxiosError) => {
+      handleError(error);
+    },
+  });
+}

--- a/src/hooks/api/project/projectId/requestJoin/usePostProjectRequestJoinDecline.tsx
+++ b/src/hooks/api/project/projectId/requestJoin/usePostProjectRequestJoinDecline.tsx
@@ -1,0 +1,41 @@
+import useErrorHandler from '@hooks/common/useErrorHandler';
+import { useMutation } from '@tanstack/react-query';
+import { ProjectInviteSuccessType } from '@type/index';
+import { ApiResponse, http } from '@utils/API';
+import { AxiosError } from 'axios';
+import toast from 'react-hot-toast';
+
+interface ProjectRequestJoinDeclineDTO {
+  projectId: number;
+  peerId: number;
+}
+
+interface ProjectRequestJoinDeclineDTO extends ProjectInviteSuccessType {}
+
+const postProjectRequestJoinDecline = async ({
+  projectId,
+  peerId,
+}: ProjectRequestJoinDeclineDTO): Promise<
+  ApiResponse<ProjectRequestJoinDeclineDTO>
+> => {
+  return await http.post(
+    `/project/${projectId}/request-join/${peerId}/decline`,
+    {
+      projectId,
+      peerId,
+    },
+  );
+};
+
+export default function usePostProjectRequestJoinDecline() {
+  const { handleError } = useErrorHandler();
+  return useMutation({
+    mutationFn: postProjectRequestJoinDecline,
+    onSuccess: () => {
+      toast.success('프로젝트 참여 신청이 거절되었습니다');
+    },
+    onError: (error: AxiosError) => {
+      handleError(error);
+    },
+  });
+}

--- a/src/hooks/store/useReviewState.tsx
+++ b/src/hooks/store/useReviewState.tsx
@@ -50,6 +50,13 @@ export default function useReviewState() {
     }));
   };
 
+  const handleChangeSubTargetId = (subTargetId: string) => {
+    setReview(prev => ({
+      ...prev,
+      subTargetId,
+    }));
+  };
+
   const handleChangePeerName = (peerName: string) => {
     setReview(prev => ({
       ...prev,
@@ -68,6 +75,7 @@ export default function useReviewState() {
     handleClearReviews,
     handleChangeUuid,
     handleChangeTargetId,
+    handleChangeSubTargetId,
     handleChangePeerName,
   };
 }

--- a/src/pages/home/index/molecule/UserProfileList.tsx
+++ b/src/pages/home/index/molecule/UserProfileList.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/common/atom/Button';
+import Typography from '@components/common/atom/Typography';
 import ProfileListItem from '@components/common/molecule/ProfileListItem';
 import { useFlow } from '@hooks/common/useStackFlow';
 import EmptyData from '@pages/home/index/atom/EmptyData';
@@ -38,7 +39,13 @@ export default function UserProfileList({
                 buttonVariant="tertiary"
                 onClick={() => handlePeerDetail(user.memberId.toString())}
               >
-                자세히
+                <Typography
+                  variant="body03"
+                  fontColor="gray08"
+                  className="!whitespace-nowrap"
+                >
+                  자세히
+                </Typography>
               </Button>
             </ProfileListItem>
           </li>

--- a/src/pages/mypage/moreFeedback/template/MoreFeedbackPage.tsx
+++ b/src/pages/mypage/moreFeedback/template/MoreFeedbackPage.tsx
@@ -22,6 +22,7 @@ const MoreFeedbackPage: ActivityComponentType = () => {
         <Header.TopBar>
           <Header.BackIcon handleClick={handleBack} />
           <Header.Title className="mx-auto">동료들의 한 줄 피드백</Header.Title>
+          <Header.RightButton text="" handleClick={() => null} />
         </Header.TopBar>
       </Header>
       <Content>

--- a/src/pages/mypage/moreFeedback/template/MorePeerFeedbackPage.tsx
+++ b/src/pages/mypage/moreFeedback/template/MorePeerFeedbackPage.tsx
@@ -33,6 +33,7 @@ const MorePeerFeedbackPage: ActivityComponentType<
         <Header.TopBar>
           <Header.BackIcon handleClick={handleBack} />
           <Header.Title className="mx-auto">동료들의 한 줄 피드백</Header.Title>
+          <Header.RightButton text="" handleClick={() => null} />
         </Header.TopBar>
       </Header>
       <Content>

--- a/src/pages/mypage/profileEdit/template/ProfileEditPage.tsx
+++ b/src/pages/mypage/profileEdit/template/ProfileEditPage.tsx
@@ -74,6 +74,7 @@ const ProfileEditPage: ActivityComponentType = () => {
         <Header.TopBar>
           <Header.BackIcon handleClick={handleBack} />
           <Header.Title className="mx-auto">프로필 수정</Header.Title>
+          <Header.RightButton text="" handleClick={() => null} />
         </Header.TopBar>
       </Header>
       <Content>

--- a/src/pages/mypage/setting/template/SettingPage.tsx
+++ b/src/pages/mypage/setting/template/SettingPage.tsx
@@ -39,6 +39,7 @@ const SettingPage: ActivityComponentType = () => {
         <Header.TopBar>
           <Header.BackIcon handleClick={handleClick} />
           <Header.Title className="mx-auto">설정</Header.Title>
+          <Header.RightButton text="" handleClick={() => null} />
         </Header.TopBar>
       </Header>
       <SettingMenu handleDelete={handleDelete} />

--- a/src/pages/notification/index/molecule/ProjectType.tsx
+++ b/src/pages/notification/index/molecule/ProjectType.tsx
@@ -170,6 +170,7 @@ export class ProjectRequestJoin implements ProjectBase {
   }
 
   display(push: PushFunction<string>) {
+    console.log(this.params);
     return (
       <ListItemContainer>
         <div className="flex gap-3">

--- a/src/pages/notification/index/molecule/ProjectType.tsx
+++ b/src/pages/notification/index/molecule/ProjectType.tsx
@@ -76,7 +76,11 @@ export class ProjectRecruitPropose implements ProjectBase {
             buttonSize="sm"
             onClick={() => push(this.activity as string, this.params)}
           >
-            <Typography variant="body03" fontColor="gray08">
+            <Typography
+              variant="body03"
+              fontColor="gray08"
+              className="!whitespace-nowrap"
+            >
               자세히
             </Typography>
           </Button>
@@ -139,6 +143,75 @@ export class ProjectProposeResult implements ProjectBase {
               </Typography>
             </div>
           </div>
+        </div>
+      </ListItemContainer>
+    );
+  }
+}
+
+export class ProjectRequestJoin implements ProjectBase {
+  private readonly activity: ActivityTypes;
+  private readonly params: Record<string, string>;
+  private readonly title: string;
+  private readonly subtitle: string;
+  private readonly readFlag: boolean;
+
+  constructor(
+    params: Record<string, string>,
+    title: string,
+    subtitle: string,
+    readFlag: boolean,
+  ) {
+    this.activity = 'ProjectJoinPage';
+    this.params = params;
+    this.title = title;
+    this.subtitle = subtitle;
+    this.readFlag = readFlag;
+  }
+
+  display(push: PushFunction<string>) {
+    return (
+      <ListItemContainer>
+        <div className="flex gap-3">
+          <div
+            className={`w-[24px] h-[24px] p-3 box-content rounded-full bg-primary200`}
+          >
+            <SvgIcon id="DocumentText" color="primary400" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Typography variant="body01">{this.title}</Typography>
+            <div className="flex flex-row gap-1">
+              <Typography
+                variant="body05"
+                fontColor="gray05"
+                className="text-left"
+              >
+                {this.subtitle}
+              </Typography>
+              <Typography
+                variant="body05"
+                fontColor="gray05"
+                className="text-left"
+              >
+                {this.readFlag ? '읽음' : '읽지않음'}
+              </Typography>
+            </div>
+          </div>
+        </div>
+        <div>
+          <Button
+            buttonVariant="tertiary"
+            buttonSize="sm"
+            onClick={() => push(this.activity as string, this.params)}
+          >
+            <Typography
+              variant="body03"
+              fontColor="gray08"
+              className="!whitespace-nowrap"
+            >
+              자세히
+            </Typography>
+          </Button>
         </div>
       </ListItemContainer>
     );

--- a/src/pages/notification/index/organism/ProjectNotificationTab.tsx
+++ b/src/pages/notification/index/organism/ProjectNotificationTab.tsx
@@ -44,7 +44,10 @@ export default function ProjectNotificationTab() {
           group.result.map((notification, index) => {
             const NotificationInstance = createAlarmInstance(
               notification.noticeType,
-              { id: String(notification.targetId) },
+              {
+                id: String(notification.targetId),
+                subTargetId: String(notification.subTargetId),
+              },
               notification.contents,
               getTimeDifference(notification.createdTime),
               notification.readFlag,

--- a/src/pages/notification/index/organism/ProjectNotificationTab.tsx
+++ b/src/pages/notification/index/organism/ProjectNotificationTab.tsx
@@ -4,6 +4,7 @@ import Project from '@pages/notification/index/molecule/Project';
 import {
   ProjectProposeResult,
   ProjectRecruitPropose,
+  ProjectRequestJoin,
 } from '@pages/notification/index/molecule/ProjectType';
 import { NoticeType } from '@type/enums';
 import { getTimeDifference } from '@utils/date';
@@ -20,8 +21,9 @@ export default function ProjectNotificationTab() {
     readFlag: boolean,
   ) => {
     switch (type) {
-      case NoticeType.INVITE_TO_PROJECT:
       case NoticeType.REQUEST_JOIN_PROJECT:
+        return new ProjectRequestJoin(params, title, subtitle, readFlag);
+      case NoticeType.INVITE_TO_PROJECT:
         return new ProjectRecruitPropose(params, title, subtitle, readFlag);
       case NoticeType.ACCEPT_PROJECT_JOIN_REQUEST:
       case NoticeType.DECLINE_PROJECT_JOIN_REQUEST:

--- a/src/pages/peer/detail/template/PeerDetailPage.tsx
+++ b/src/pages/peer/detail/template/PeerDetailPage.tsx
@@ -76,6 +76,7 @@ const PeerDetailPage: ActivityComponentType<peerDetailPageParams> = ({
           <Header.TopBar>
             <Header.BackIcon handleClick={handleBack} />
             <Header.Title className="mx-auto">{username}</Header.Title>
+            <Header.RightButton text="" handleClick={() => null} />
           </Header.TopBar>
         </Header>
         <PeerProfileCard memberInfo={memberSimpleProfileDto} />

--- a/src/pages/peer/onboard/template/OnboardingPage.tsx
+++ b/src/pages/peer/onboard/template/OnboardingPage.tsx
@@ -11,7 +11,7 @@ import useReviewState from '@hooks/store/useReviewState';
 import OnboardingCard from '@pages/peer/onboard/organism/OnboardingCard';
 import { ActivityComponentType } from '@stackflow/react';
 import { getAccessToken, getRefreshToken } from '@utils/token';
-import { useEffect } from 'react';
+import { Fragment, useEffect } from 'react';
 
 type OnboardingPageParams = {
   step: string;
@@ -65,10 +65,13 @@ const OnboardingPage: ActivityComponentType<OnboardingPageParams> = ({
             <Header.BackIcon handleClick={handleClickBackIcon} />
           )}
           {isShowRightButton && (
-            <Header.RightButton
-              text="바로시작하기"
-              handleClick={handleClickStart}
-            />
+            <Fragment>
+              <div className="w-[24]" />
+              <Header.RightButton
+                text="바로시작하기"
+                handleClick={handleClickStart}
+              />
+            </Fragment>
           )}
         </Header.TopBar>
       </Header>

--- a/src/pages/peer/project/template/MyProjectListPage.tsx
+++ b/src/pages/peer/project/template/MyProjectListPage.tsx
@@ -7,7 +7,7 @@ import AppScreenContainer from '@components/wrapper/AppScreenContainter';
 import Footer from '@components/wrapper/Footer';
 import Header from '@components/wrapper/Header';
 import useGetMyProjectList from '@hooks/api/project/index/useGetMyProjectList';
-import usePostProjectRespondInvitation from '@hooks/api/project/projectId/usePostProjectRespondInvitation';
+import usePostPeerInviteProject from '@hooks/api/project/projectId/usePostPeerInviteProject';
 import useIntersection from '@hooks/common/useIntersection';
 import { useFlow } from '@hooks/common/useStackFlow';
 import { Spacer } from '@nextui-org/react';
@@ -28,7 +28,7 @@ const MyProjectListPage: ActivityComponentType<MyProjectListPageParams> = ({
   const { data, fetchNextPage, isFetchingNextPage } = useGetMyProjectList();
 
   const intersectionRef = useIntersection(fetchNextPage);
-  const { mutate } = usePostProjectRespondInvitation();
+  const { mutate } = usePostPeerInviteProject();
 
   const handleInvite = () => {
     if (selectedProjectId) {
@@ -44,9 +44,10 @@ const MyProjectListPage: ActivityComponentType<MyProjectListPageParams> = ({
         <Header.TopBar>
           <Header.BackIcon handleClick={handleBack} />
           <Header.Title className="mx-auto">내 프로젝트</Header.Title>
+          <Header.RightButton text="" handleClick={() => null} />
         </Header.TopBar>
       </Header>
-      <div className="w-full flex flex-col justify-start">
+      <div className="w-full flex flex-col justify-start px-4">
         <Typography
           variant="caption01"
           fontColor="gray04"

--- a/src/pages/project/create/organism/ProjectForm.tsx
+++ b/src/pages/project/create/organism/ProjectForm.tsx
@@ -47,17 +47,22 @@ export default function ProjectForm() {
     );
   };
 
-  const { mutate } = usePostCreateProject(() => push('ProjectPage', {}));
+  const { mutate } = usePostCreateProject();
   const handleSubmit = () => {
-    mutate({
-      projectName: projectName,
-      introduce: introduce,
-      openChattingLink: openChattingLink,
-      notionLink: notionLink,
-      githubLink: githubLink,
-      startDate: startDate,
-      endDate: endDate,
-    });
+    mutate(
+      {
+        projectName: projectName,
+        introduce: introduce,
+        openChattingLink: openChattingLink,
+        notionLink: notionLink,
+        githubLink: githubLink,
+        startDate: startDate,
+        endDate: endDate,
+      },
+      {
+        onSuccess: () => push('ProjectPage', {}),
+      },
+    );
   };
 
   return (

--- a/src/pages/project/create/template/ProjectCreatePage.tsx
+++ b/src/pages/project/create/template/ProjectCreatePage.tsx
@@ -15,6 +15,7 @@ const ProjectCreatePage: ActivityComponentType = () => {
         <Header.TopBar>
           <Header.BackIcon handleClick={handleClickBackIcon} />
           <Header.Title className="mx-auto">프로젝트 생성</Header.Title>
+          <Header.RightButton text="" handleClick={() => null} />
         </Header.TopBar>
       </Header>
       <Content>

--- a/src/pages/project/join/atom/JoinRequestAccept.tsx
+++ b/src/pages/project/join/atom/JoinRequestAccept.tsx
@@ -1,0 +1,3 @@
+export default function JoinRequestAccept() {
+  return <div>JoinRequestAccept</div>;
+}

--- a/src/pages/project/join/template/ProjectJoinPage.tsx
+++ b/src/pages/project/join/template/ProjectJoinPage.tsx
@@ -1,0 +1,175 @@
+import Button from '@components/common/atom/Button';
+import Typography from '@components/common/atom/Typography';
+import RadioTabs from '@components/common/molecule/RadioTabs';
+import AppScreenContainer from '@components/wrapper/AppScreenContainter';
+import Content from '@components/wrapper/Content';
+import Footer from '@components/wrapper/Footer';
+import Header from '@components/wrapper/Header';
+import useGetPeerDetail from '@hooks/api/home/peerId/useGetPeerDetail';
+import usePostProjectRequestJoinAccept from '@hooks/api/project/projectId/requestJoin/usePostProjectRequestJoinAccept';
+import { useFlow } from '@hooks/common/useStackFlow';
+import { Spacer, Tab } from '@nextui-org/react';
+import Feedback from '@pages/mypage/index/molecule/Feedback';
+import HeaderContainer from '@pages/mypage/index/molecule/HeaderContainer';
+import NoTestKeywordResult from '@pages/mypage/index/molecule/NoTestKeywordResult';
+import OverallOpinion from '@pages/mypage/index/molecule/OverallOpinion';
+import OverallScore from '@pages/mypage/index/molecule/OverallScore';
+import OverallTestResult from '@pages/mypage/index/molecule/OverallTestResult';
+import Layout from '@pages/mypage/index/organism/Layout';
+import PeerProfileCard from '@pages/peer/detail/atom/PeerProfileCard';
+import PeerTestResult from '@pages/peer/detail/atom/PeerTestResult';
+import SelfTestResult from '@pages/peer/detail/atom/SelfTestResult';
+import ProjectList from '@pages/peer/detail/molecule/ProjectList';
+import { ActivityComponentType } from '@stackflow/react';
+
+interface ProjectJoinPageParams {
+  id: string;
+  subTargetId: string;
+}
+
+const ProjectJoinPage: ActivityComponentType<ProjectJoinPageParams> = ({
+  params,
+}) => {
+  const projectId = params.id;
+  const memberId = params.subTargetId;
+  const { pop, push } = useFlow();
+
+  const { data: peerInfo } = useGetPeerDetail(parseInt(memberId));
+  console.log(peerInfo);
+
+  const {
+    peerTestMoreThanThree,
+    memberSimpleProfileDto,
+    peerCardList,
+    myCardList,
+    myName,
+    totalEvaluation,
+    totalScore,
+    peerFeedbackList,
+    peerAnswerIdList,
+    colorAnswerIdList,
+    peerProjectDtoList,
+  } = peerInfo;
+
+  const handleMoreFeedback = () => {
+    push('MorePeerFeedbackPage', { memberId: memberId });
+  };
+
+  const handleMoreProject = () => {
+    push('MorePeerProjectPage', { memberId: memberId });
+  };
+
+  const acceptMutation = usePostProjectRequestJoinAccept();
+  const declineMutation = usePostProjectRequestJoinAccept();
+
+  const handleClickAccept = () => {
+    acceptMutation.mutate(
+      {
+        peerId: parseInt(memberId),
+        projectId: parseInt(projectId),
+      },
+      {
+        onSuccess: () => push('NotificationPage', {}),
+      },
+    );
+  };
+
+  const handleMyProjectList = () => {
+    declineMutation.mutate(
+      {
+        peerId: parseInt(memberId),
+        projectId: parseInt(projectId),
+      },
+      {
+        onSuccess: () => push('NotificationPage', {}),
+      },
+    );
+  };
+
+  const username = memberSimpleProfileDto.name;
+
+  const handleBack = () => pop();
+
+  return (
+    <AppScreenContainer>
+      <Content>
+        <div className="bg-peer-bg bg-cover bg-no-repeat w-full">
+          <Header>
+            <Header.TopBar>
+              <Header.BackIcon handleClick={handleBack} />
+              <Header.Title className="mx-auto">{username}</Header.Title>
+            </Header.TopBar>
+          </Header>
+          <PeerProfileCard memberInfo={memberSimpleProfileDto} />
+          <Layout>
+            <HeaderContainer size="md">
+              <Typography
+                variant="header02"
+                fontColor="gray08"
+                className="mb-2"
+              >
+                {
+                  '함께 한 동료들이 남긴 \n 피어 테스트 응답을 바탕으로 분석했어요'
+                }
+              </Typography>
+              <Typography variant="body01" fontColor="gray06">
+                나와 동료의 협업 유형을 상세하게 비교해보세요
+              </Typography>
+            </HeaderContainer>
+            <RadioTabs>
+              <Tab key="me" title="카드비교" className="px-4">
+                <PeerTestResult user={username} peerCardList={peerCardList} />
+                <SelfTestResult myName={myName} myCardList={myCardList} />
+                {Array.isArray(totalEvaluation) &&
+                  peerTestMoreThanThree === true && (
+                    <OverallOpinion totalEvaluation={totalEvaluation} />
+                  )}
+                {peerTestMoreThanThree && totalScore && (
+                  <OverallScore totalScore={totalScore} />
+                )}
+                {peerTestMoreThanThree && peerFeedbackList && (
+                  <Feedback
+                    peerFeedbackList={peerFeedbackList}
+                    handleClick={handleMoreFeedback}
+                  />
+                )}
+                {peerProjectDtoList && (
+                  <ProjectList
+                    projectList={peerProjectDtoList}
+                    handleClick={handleMoreProject}
+                  />
+                )}
+              </Tab>
+              <Tab key="peer" title="키워드 비교" className="px-4">
+                {peerTestMoreThanThree && (
+                  <OverallTestResult
+                    colorAnswerIdList={colorAnswerIdList}
+                    selfTestAnswerIdList={peerAnswerIdList}
+                    peerCardList={peerCardList}
+                    type="peer"
+                  />
+                )}
+                {!peerTestMoreThanThree && <NoTestKeywordResult type="peer" />}
+              </Tab>
+            </RadioTabs>
+          </Layout>
+        </div>
+        <Spacer y={16} />
+      </Content>
+      <Footer bottom={3} className="px-4">
+        <div className="flex flex-row gap-4">
+          <Button buttonVariant="tertiary" onClick={handleMyProjectList}>
+            <Typography variant="body01">거절</Typography>
+          </Button>
+          <Button onClick={handleClickAccept}>
+            <Typography variant="body01" fontColor="white">
+              수락
+            </Typography>
+          </Button>
+        </div>
+      </Footer>
+    </AppScreenContainer>
+  );
+};
+
+export default ProjectJoinPage;

--- a/src/pages/project/projectId/molecule/ProjectCreatorProfile.tsx
+++ b/src/pages/project/projectId/molecule/ProjectCreatorProfile.tsx
@@ -62,7 +62,13 @@ export default function ProjectCreatorProfile({
           buttonSize="sm"
           onClick={handleClickDetail}
         >
-          자세히
+          <Typography
+            variant="body03"
+            fontColor="gray08"
+            className="!whitespace-nowrap"
+          >
+            자세히
+          </Typography>
         </Button>
       </div>
     </div>

--- a/src/pages/review/peer/organism/RequestInit.tsx
+++ b/src/pages/review/peer/organism/RequestInit.tsx
@@ -29,6 +29,7 @@ export default function RequestInit({ uuid, memberId }: RequestInitProps) {
     if (username) {
       handleChangeUuid(uuid!);
       handleChangeTargetId(memberId!);
+
       handleChangePeerName(username);
     }
   }, []);

--- a/src/store/reviewState.ts
+++ b/src/store/reviewState.ts
@@ -16,6 +16,7 @@ type ReviewStateTypes = {
   feedback: string;
   uuid?: string;
   targetId?: string;
+  subTargetId?: string;
   peerName?: string;
 };
 

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -19,6 +19,7 @@ export interface ProjectItemType {
 
 export interface NotificationItemType {
   targetId: number;
+  subTargetId: number;
   noticeType: NoticeType;
   contents: string;
   createdTime: string;


### PR DESCRIPTION
## 체크리스트
- [x] PR 제목의 형식 e.g. `feat: PR 등록`
- [x] Issue 
- [x] Label 
- [x] Assignees & Reviewers 

<br>

## PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
프로젝트 참가 신청에 대해 수락/거부 기능을 구현하였습니다.
<br><br>

## 상세 작업 내용
<!-- 작업한 상세 내용을 작성해 주세요.-->
- Notification 조회시 targetId, subTargetId가 와서 page params로 넘기면 됩니다. 
- peer detail 컴포넌트를 그대로 갖다썼는데, 나중에 컴포넌트로 만들어서 Suspense를 사용할 수 있게 변경해야 할 것 같습니다. 
<br><br>

## 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 닫힙니다. -->
<!-- ex) Close #14 -->

- Close #100 

<br><br>
