### PR TITLE
fix: 홈에서 api 호출 문제 해결

### DIFF
--- a/src/hooks/api/home/search/useGetSearchPeerPart.tsx
+++ b/src/hooks/api/home/search/useGetSearchPeerPart.tsx
@@ -1,3 +1,4 @@
+import { UtilityKeys } from '@constants/localStorage';
 import { QUERY_KEY } from '@constants/queryKey';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { PeerSimpleProfileType } from '@type/index';
@@ -7,6 +8,21 @@ const getSearchPeerPart = async (
   peerPart: string,
   page: number,
 ): Promise<InfiniteApiResponse<PeerSimpleProfileType>> => {
+  const isOnboarding = localStorage.getItem(UtilityKeys.IS_ONBOARD);
+  if (!isOnboarding) {
+    return {
+      code: 0,
+      message: '',
+      result: [],
+      pageRequestDto: {
+        totalElements: 0,
+        currentPageElements: 0,
+        totalPage: 0,
+        isFirst: true,
+        isLast: true,
+      },
+    };
+  }
   const response = await http.get(
     `/home/search/peer-part?part=${peerPart}&page=${page}`,
   );

--- a/src/hooks/api/member/index/useGetMe.tsx
+++ b/src/hooks/api/member/index/useGetMe.tsx
@@ -1,5 +1,7 @@
+import { UtilityKeys } from '@constants/localStorage';
 import { QUERY_KEY } from '@constants/queryKey';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { JobType, PartType } from '@type/enums';
 import { MemberDefaultInformationTypeWithUuid } from '@type/index';
 import { ApiResponse, http } from '@utils/API';
 
@@ -7,6 +9,19 @@ export interface MemberMeResponseDTO
   extends MemberDefaultInformationTypeWithUuid {}
 
 const getMe = async (): Promise<ApiResponse<MemberMeResponseDTO>> => {
+  const isOnboarding = localStorage.getItem(UtilityKeys.IS_ONBOARD);
+  if (!isOnboarding)
+    return {
+      code: 0,
+      message: '',
+      result: {
+        name: '',
+        uuid: '',
+        job: JobType.ENTREPRENEUR,
+        part: PartType.BACK_END,
+        oneLiner: '',
+      },
+    };
   const response = await http.get('/member/me');
   return response.data;
 };

--- a/src/hooks/api/member/index/useGetMe.tsx
+++ b/src/hooks/api/member/index/useGetMe.tsx
@@ -1,7 +1,6 @@
 import { UtilityKeys } from '@constants/localStorage';
 import { QUERY_KEY } from '@constants/queryKey';
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { JobType, PartType } from '@type/enums';
+import { useQuery } from '@tanstack/react-query';
 import { MemberDefaultInformationTypeWithUuid } from '@type/index';
 import { ApiResponse, http } from '@utils/API';
 
@@ -9,27 +8,17 @@ export interface MemberMeResponseDTO
   extends MemberDefaultInformationTypeWithUuid {}
 
 const getMe = async (): Promise<ApiResponse<MemberMeResponseDTO>> => {
-  const isOnboarding = localStorage.getItem(UtilityKeys.IS_ONBOARD);
-  if (!isOnboarding)
-    return {
-      code: 0,
-      message: '',
-      result: {
-        name: '',
-        uuid: '',
-        job: JobType.ENTREPRENEUR,
-        part: PartType.BACK_END,
-        oneLiner: '',
-      },
-    };
   const response = await http.get('/member/me');
   return response.data;
 };
 
 export default function useGetMe() {
-  return useSuspenseQuery({
+  const isOnboarding = localStorage.getItem(UtilityKeys.IS_ONBOARD);
+
+  return useQuery({
     queryKey: [QUERY_KEY.MEMBER_ME],
     queryFn: getMe,
     select: data => data.result,
+    enabled: !isOnboarding,
   });
 }

--- a/src/pages/home/index/atom/ReviewButton.tsx
+++ b/src/pages/home/index/atom/ReviewButton.tsx
@@ -6,7 +6,7 @@ import useSendKakaoMessage from '@hooks/common/useSendKakoMessage';
 
 export default function ReviewButton() {
   const { data } = useGetMe();
-  const uuid = data.uuid;
+  const uuid = data ? data.uuid : '';
 
   const handleSendKakaoMessage = useSendKakaoMessage();
   const title = '저는 어떤 동료인가요?';

--- a/src/pages/home/index/template/HomePage.tsx
+++ b/src/pages/home/index/template/HomePage.tsx
@@ -29,36 +29,26 @@ import PeerTypeAvatarList from '../molecule/PeerTypeAvatarList';
 import UserProfileList from '../molecule/UserProfileList';
 
 const HomePage: ActivityComponentType = () => {
-  const [currentTab, setCurrentTab] = useState('ALL');
-
-  const { data, refetch, isFetchingNextPage, fetchNextPage } =
-    useGetSearchPeerPart(currentTab);
-
-  console.log(data);
-
-  useEffect(() => {
-    refetch();
-  }, [currentTab]);
-
   const { push } = useFlow();
 
   const { openModal: openModalLogin } = useModal('login');
   const { openModal: openModalPush } = useModal('push');
   const { handleClearHistory } = useHistory();
   const { handleClearReviews } = useReviewState();
+  const hasToken = getAccessToken();
+
+  const isOnboarding = localStorage.getItem(UtilityKeys.IS_ONBOARD);
+  if (!isOnboarding && !hasToken) {
+    push('OnboardingPage', { step: '1' });
+  }
+
   useEffect(() => {
     handleClearHistory();
     handleClearReviews();
     // 온보딩을 해본 유저인지 확인
-    const hasToken = getAccessToken();
     const isOnboarding = localStorage.getItem(UtilityKeys.IS_ONBOARD);
     const rawIsPushAgree = localStorage.getItem(UtilityKeys.IS_PUSH_AGREE);
     const isPushAgree = rawIsPushAgree === 'true';
-
-    // 온보딩을 안했고, 로그인이 되지 않았다면
-    if (!isOnboarding && !hasToken) {
-      push('OnboardingPage', { step: '1' });
-    }
 
     // 온보딩을 했고, 로그인이 되어 있는 상태에서 푸시 알림 허용을 안했으면
     if (isOnboarding && hasToken && !isPushAgree) {
@@ -69,6 +59,15 @@ const HomePage: ActivityComponentType = () => {
       openModalLogin();
     }
   }, []);
+
+  const [currentTab, setCurrentTab] = useState('ALL');
+
+  const { data, refetch, isFetchingNextPage, fetchNextPage } =
+    useGetSearchPeerPart(currentTab);
+
+  useEffect(() => {
+    refetch();
+  }, [currentTab]);
 
   const intersectionRef = useIntersection(fetchNextPage);
 
@@ -98,7 +97,9 @@ const HomePage: ActivityComponentType = () => {
               </Typography>
             </HeaderContainer>
             <PeerTypeAvatarList />
-            <ReviewButton />
+            <ErrorBoundaryWithSuspense>
+              <ReviewButton />
+            </ErrorBoundaryWithSuspense>
             <UnderlineTabs
               selectedKey={currentTab}
               onSelectionChange={key => setCurrentTab(key as PartType)}

--- a/src/pages/mypage/index/template/MyPage.tsx
+++ b/src/pages/mypage/index/template/MyPage.tsx
@@ -29,7 +29,6 @@ import Layout from '../organism/Layout';
 
 const MyPage: ActivityComponentType = () => {
   const { data } = useGetMyPageInfo();
-  console.log(data);
 
   const {
     peerTestMoreThanThree,
@@ -44,8 +43,6 @@ const MyPage: ActivityComponentType = () => {
     selfTestAnswerIdList,
     peerFeedbackList,
   } = data;
-
-  console.log(!!totalScore);
 
   const { push } = useFlow();
   const selfTestType = memberMyPageInfoDto.testType;


### PR DESCRIPTION
## 체크리스트
- [x] PR 제목의 형식 e.g. `feat: PR 등록`
- [ ] Issue 
- [x] Label 
- [x] Assignees & Reviewers 

<br>

## PR 한 줄 요약
- 홈에서 api 호출로 온보딩으로 이동하지 않는 문제가 있습니다. 

<br><br>

## 상세 작업 내용
- 홈에서 api 호출 시, interceptor로 잡히지 않아 홈에서 각 api에서 온보딩이 null이면 빈 데이터를 반환하도록 추가하였습니다.
- useEffect 안에서 token과 온보딩 여부를 검사해서 이동하지 않고 바로 이동할 수 있도록 수정하였습니다.


<br><br>
