### PR TITLE
fix: useGetMe 쿼리 에러 해결 및 tooltip 이슈

### DIFF
--- a/src/hooks/api/member/index/useGetMe.tsx
+++ b/src/hooks/api/member/index/useGetMe.tsx
@@ -21,6 +21,6 @@ export default function useGetMe() {
     queryKey: [QUERY_KEY.MEMBER_ME],
     queryFn: getMe,
     select: data => data.result,
-    enabled: !isOnboarding || !!hasToken,
+    enabled: !!isOnboarding || !!hasToken,
   });
 }

--- a/src/pages/mypage/index/atom/PeerToolTip.tsx
+++ b/src/pages/mypage/index/atom/PeerToolTip.tsx
@@ -1,0 +1,38 @@
+import SvgIcon from '@components/common/atom/SvgIcon';
+import { Button, Tooltip } from '@nextui-org/react';
+import { useState } from 'react';
+
+type PeerToolTipProps = {
+  type: 'peer' | 'self';
+};
+
+export default function PeerToolTip({ type }: PeerToolTipProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const toolTip =
+    type === 'self' ? (
+      <>
+        셀프 테스트, 피어 테스트 문항의
+        <br />
+        일치하는 선택지를 확인하세요
+      </>
+    ) : (
+      <>
+        나와 동료의 협업 유형 분석 결과
+        <br />
+        일치하는 선택지를 확인하세요
+      </>
+    );
+  return (
+    <Tooltip content={toolTip} isOpen={isOpen}>
+      <Button
+        className="bg-transparent !min-w-unit-0 !px-unit-0"
+        onMouseEnter={() => setIsOpen(true)}
+        onMouseLeave={() => setIsOpen(false)}
+        onPress={() => setIsOpen(!isOpen)}
+      >
+        <SvgIcon id="Help" color="gray04" width={16} height={16} />
+      </Button>
+    </Tooltip>
+  );
+}

--- a/src/pages/mypage/index/molecule/NoTestKeywordResult.tsx
+++ b/src/pages/mypage/index/molecule/NoTestKeywordResult.tsx
@@ -1,7 +1,6 @@
-import SvgIcon from '@components/common/atom/SvgIcon';
 import Typography from '@components/common/atom/Typography';
 import NoKeywordCard from '@components/common/molecule/NoKeywordCard';
-import { Button, Tooltip } from '@nextui-org/react';
+import PeerToolTip from '@pages/mypage/index/atom/PeerToolTip';
 import HeaderContainer from './HeaderContainer';
 
 type KeywordProps = {
@@ -31,21 +30,6 @@ export default function NoTestKeywordResult({ type }: KeywordProps) {
   const title =
     type === 'self' ? '나도 알고 동료도 아는 내 모습' : '나와 동료의 공통점';
 
-  const toolTip =
-    type === 'self' ? (
-      <>
-        셀프 테스트, 피어 테스트 문항의
-        <br />
-        일치하는 선택지를 확인하세요
-      </>
-    ) : (
-      <>
-        나와 동료의 협업 유형 분석 결과
-        <br />
-        일치하는 선택지를 확인하세요
-      </>
-    );
-
   return (
     <>
       <HeaderContainer size="sm">
@@ -53,14 +37,10 @@ export default function NoTestKeywordResult({ type }: KeywordProps) {
           <Typography variant="header03" fontColor="gray08">
             {title}
           </Typography>
-          <Tooltip content={toolTip}>
-            <Button className="bg-transparent !min-w-unit-0 !px-unit-0">
-              <SvgIcon id="Help" color="gray04" width={16} height={16} />
-            </Button>
-          </Tooltip>
+          <PeerToolTip type={type} />
         </div>
       </HeaderContainer>
-      <section className="flex flex-col gap-3 items-center">
+      <section className="flex flex-col gap-3 items-center px-4">
         {NoKeywordTitles.map(({ title, subtitle }) => (
           <NoKeywordCard key={title} title={title} subtitle={subtitle} />
         ))}

--- a/src/pages/mypage/index/molecule/OverallTestResult.tsx
+++ b/src/pages/mypage/index/molecule/OverallTestResult.tsx
@@ -75,7 +75,7 @@ export default function OverallTestResult({
           </Tooltip>
         </div>
       </HeaderContainer>
-      <section className="flex flex-col gap-3 items-center">
+      <section className="flex flex-col gap-3 items-center px-4">
         <KeywordCard
           title="가치관"
           subtitle={KEYWORD_CARD_INFO[peerCardList[0]].content as string}


### PR DESCRIPTION
## 체크리스트
- [x] PR 제목의 형식 e.g. `feat: PR 등록`
- [ ] Issue 
- [x] Label 
- [x] Assignees & Reviewers 

<br>

## PR 한 줄 요약
- useGetMe 쿼리에서 isOnboarding 여부 이중부정연산자로 수정하였습니다.
- tooltip이 모바일에서 보이지 않는 이슈를 useState로 제어하여 수정하였습니다.
- 에러 핸들러 훅에서 상태관리가 아닌 useModal 훅을 사용하였습니다.

<br><br>

## 관련 이슈

- Close #134 

<br><br>
